### PR TITLE
com.palm.app.notes: Add mock data

### DIFF
--- a/com.palm.app.calendar/mock/databaseManager_merge.json
+++ b/com.palm.app.calendar/mock/databaseManager_merge.json
@@ -1,0 +1,4 @@
+{
+	"returnValue": true,
+	"count": 1
+}

--- a/com.palm.app.notes/mock/del.json
+++ b/com.palm.app.notes/mock/del.json
@@ -1,0 +1,7 @@
+{
+	"returnValue": true,
+	"results": [{
+		"id": "++KK_FJv2N+AAtmQ",
+		"rev": 10876
+	}]
+}

--- a/com.palm.app.notes/mock/find.json
+++ b/com.palm.app.notes/mock/find.json
@@ -1,0 +1,24 @@
+{
+	"returnValue": true,
+	"results": [{
+		"_id": "++KK_FMaE8ozrlVs",
+		"_kind": "com.palm.note:1",
+		"_rev": 10874,
+		"_sync": true,
+		"color": "pink",
+		"displayText": "Test Note 1",
+		"position": "g",
+		"text": "Test Note 1 for use on desktop",
+		"title": "Test Note 1"
+	}, {
+		"_id": "++KK_FJv2N+AAtmQ",
+		"_kind": "com.palm.note:1",
+		"_rev": 10871,
+		"_sync": true,
+		"color": "yellow",
+		"displayText": "Test Note 2",
+		"position": "m",
+		"text": "Test Note 2 for use on desktop",
+		"title": "Test Note 2"
+	}]
+}

--- a/com.palm.app.notes/mock/launch.json
+++ b/com.palm.app.notes/mock/launch.json
@@ -1,0 +1,7 @@
+{
+	"returnValue": true,
+	"results": [{
+		"id": "++KK_JzUCYxyMfKq",
+		"rev": 10881
+	}]
+}

--- a/com.palm.app.notes/mock/merge.json
+++ b/com.palm.app.notes/mock/merge.json
@@ -1,0 +1,7 @@
+{
+	"returnValue": true,
+	"results": [{
+		"id": "++KK_FMaE8ozrlVs",
+		"rev": 10874
+	}]
+}

--- a/com.palm.app.notes/mock/put.json
+++ b/com.palm.app.notes/mock/put.json
@@ -1,0 +1,7 @@
+{
+	"returnValue": true,
+	"results": [{
+		"id": "++KK_FkmrlkTfd+G",
+		"rev": 10875
+	}]
+}

--- a/com.palm.app.notes/mock/search.json
+++ b/com.palm.app.notes/mock/search.json
@@ -1,0 +1,25 @@
+{
+	"returnValue": true,
+	"results": [{
+		"_id": "++KK_FMaE8ozrlVs",
+		"_kind": "com.palm.note:1",
+		"_rev": 10874,
+		"_sync": true,
+		"color": "pink",
+		"displayText": "Test Note 1",
+		"position": "g",
+		"text": "Test Note 1 for use on desktop",
+		"title": "Test Note 1"
+	}, {
+		"_id": "++KK_FJv2N+AAtmQ",
+		"_kind": "com.palm.note:1",
+		"_rev": 10871,
+		"_sync": true,
+		"color": "yellow",
+		"displayText": "Test Note 2",
+		"position": "m",
+		"text": "Test Note 2 for use on desktop",
+		"title": "Test Note 2"
+	}],
+	"count": 2
+}


### PR DESCRIPTION
Add mock data so it's usable on desktop for development.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>