### PR TITLE
calendar: don't decorate requests with $activity

### DIFF
--- a/com.palm.app.calendar/libs/Mojo.Core.Service.js
+++ b/com.palm.app.calendar/libs/Mojo.Core.Service.js
@@ -40,9 +40,15 @@ Mojo.Core.Service = (function () {
                 console.warn("No activity id available for service request!");
             }
             else {
-                parameters.$activity = {
-                    activityId: PalmSystem.activityId
-                };
+                if (true) {
+                    console.log("Mojo.Core.Service.Request: skipping problematic activity id decoration!");
+                }
+                else {
+                    // dead code
+                    parameters.$activity = {
+                        activityId: PalmSystem.activityId
+                    };
+                }
             }
         }
 


### PR DESCRIPTION
This leads to non-standard LS2 calls, which conflicts with schema checks.
Fixes message like the following:
Error: invalid parameters: caller='com.palm.app.calendar' error='property not allowed - '$activity''

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>