### PR TITLE
MailApp.js: apply more restrictive width for MessagePane

### DIFF
--- a/com.palm.app.email/mail/source/MailApp.js
+++ b/com.palm.app.email/mail/source/MailApp.js
@@ -53,7 +53,7 @@ enyo.kind({
                     onHeaderTap: "headerTap"
                 }
             ]},
-            {flex: 1, name: "bodySliding", dragAnywhere: false, onResize: "resizeBody", showing: true, components: [
+            {width: "320px", name: "bodySliding", dragAnywhere: false, fixedWidth: true, onResize: "resizeBody", showing: true, components: [
                 {
                     name: "body",
                     kind: "MessagePane",


### PR DESCRIPTION
Otherwise the MessagePane's width get always recomputed to zero.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>