### PR TITLE
Add trustLevel

### DIFF
--- a/com.palm.app.accounts/appinfo.json
+++ b/com.palm.app.accounts/appinfo.json
@@ -7,5 +7,6 @@
 	"title": "Accounts",
 	"icon": "icon.png",
 	"uiRevision": 2,
+	"trustLevel": "trusted",
 	"requiredPermissions": ["applications.internal", "applications", "activities.manage", "devices", "settings", "settings.read", "services", "database", "database.internal", "filecache", "system", "networking", "networking.internal"]
 }

--- a/com.palm.app.calculator/appinfo.json
+++ b/com.palm.app.calculator/appinfo.json
@@ -6,6 +6,7 @@
 	"main": "index.html",
 	"title": "Calculator",
 	"icon": "icon.png",
+	"trustLevel": "trusted",
 	"uiRevision": "2",
 	"removable": false
 }

--- a/com.palm.app.calendar/appinfo.json
+++ b/com.palm.app.calendar/appinfo.json
@@ -9,6 +9,7 @@
     "icon"           : "images/icon-256x256.png",
     "type"           : "web",
     "removable"      : false,
+    "trustLevel"     : "trusted",
     "keywords"       : ["Anniversaries", "Appointments", "Birthdays", "Datebook", "Events", "Meetings", "Reminders"],
     "universalSearch": {
         "action"  : {

--- a/com.palm.app.clock/appinfo.json
+++ b/com.palm.app.clock/appinfo.json
@@ -11,5 +11,6 @@
 	"uiRevision": 2,
 	"debug": false,
 	"removable": false,
+	"trustLevel" : "trusted",
 	"requiredPermissions": ["applications.internal", "applications", "activities.manage", "devices", "settings", "settings.read", "services", "database", "database.internal", "filecache", "system", "networking", "networking.internal", "time", "activities.manage", "media"]
 }

--- a/com.palm.app.contacts/appinfo.json
+++ b/com.palm.app.contacts/appinfo.json
@@ -8,5 +8,6 @@
     "title"     : "Contacts",
     "icon"      : "icon.png",
     "removable" : false,
+    "trustLevel" : "trusted",
     "requiredPermissions": ["applications.internal", "applications", "activities.manage", "devices", "settings", "settings.read", "services", "database", "database.internal", "filecache", "system", "networking", "networking.internal"]
 }

--- a/com.palm.app.email/appinfo.json
+++ b/com.palm.app.email/appinfo.json
@@ -8,6 +8,7 @@
     "icon"           : "icon.png",
     "splashicon"     : "icon-256x256.png",
     "noWindow"       : true,
+    "trustLevel"     : "trusted",
     "uiRevision"     : 2,
     "mimeTypes"      : [
         {

--- a/com.palm.app.notes/appinfo.json
+++ b/com.palm.app.notes/appinfo.json
@@ -8,6 +8,7 @@
     "removable": false,
     "uiRevision": 2,
     "main": "index.html",
+    "trustLevel" : "trusted",
     "vendor": "HP",
     "universalSearch": {
         "action": {


### PR DESCRIPTION
So that WAM will behave better with these apps since WAM has trusted locations whitelisted, which don't need to be explicitly whitelisted in the [Allowed] list.

https://github.com/webosose/wam/blob/master/files/launch/security_policy.conf

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>