### PR TITLE
com.palm.app.email: Add persmissions for powerd

### DIFF
--- a/com.palm.app.email/appinfo.json
+++ b/com.palm.app.email/appinfo.json
@@ -51,5 +51,5 @@
             }
         }
     },
-    "requiredPermissions": ["accountsservice.management", "accountsservice.operation", "activity.operation", "application.launcher", "application.operation", "database.operation", "filecache.operation", "filecache.management", "luna-sysmgr.operation", "mojomail-imap.operation", "mojomail-pop.operation", "mojomail-smtp.operation", "networkconnection.query", "settings.read", "systemsettings.query", "tempdatabase.operation"]
+    "requiredPermissions": ["accountsservice.management", "accountsservice.operation", "activity.operation", "application.launcher", "application.operation", "database.operation", "filecache.operation", "filecache.management", "luna-sysmgr.operation", "mojomail-imap.operation", "mojomail-pop.operation", "mojomail-smtp.operation", "networkconnection.query", "powerd.management", "settings.read", "systemsettings.query", "tempdatabase.operation"]
 }


### PR DESCRIPTION
Fixes:

Oct 10 11:20:48 qemux86-64 powerd[656]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.palm.app.email-42464","CATEGORY":"/com/palm/power","METHOD":"activityStart"} Service security groups don't allow method call.

Oct 10 11:20:48 qemux86-64 powerd[656]: [] [pmlog] <default-lib> LS_REQUIRES_SECURITY {"SERVICE":"com.palm.app.email-59118","CATEGORY":"/com/palm/power","METHOD":"activityEnd"} Service security groups don't allow method call.