### PR TITLE
core-apps: Fix incorrect permissions

### DIFF
--- a/com.palm.app.accounts/appinfo.json
+++ b/com.palm.app.accounts/appinfo.json
@@ -8,5 +8,5 @@
 	"icon": "icon.png",
 	"uiRevision": 2,
 	"trustLevel": "trusted",
-	"requiredPermissions": ["accountsservice.management", "accountsservice.operation", "activity.operation", "application.operation", "cdav-service.operation", "database.operation", "imaccountvalidator.operation", "keymanager-service.operation", "mojomail-imap.operation", "mojomail-pop.operation", "mojomail-smtp.operation", "networkconnection.query", "networkconnection.management", "settings.read", "tempdatabase.operation", "wifi.query", "wifi.management"]
+	"requiredPermissions": ["accountsservice.management", "accountsservice.operation", "activity.operation", "application.operation", "cdav-service.operation", "database.operation", "imaccountvalidator.operation", "keymanager-service.operation", "mojomail-imap.operation", "mojomail-pop.operation", "mojomail-smtp.operation", "networkconnection.query", "networkconnection.management", "settings.query", "tempdatabase.operation", "wifi.query", "wifi.management"]
 }

--- a/com.palm.app.calendar/appinfo.json
+++ b/com.palm.app.calendar/appinfo.json
@@ -42,5 +42,5 @@
             }
         }
     },
-    "requiredPermissions": ["accountsservice.management", "activity.operation", "appmanager.management", "application.launcher", "calendarremindersservice.operation", "database.operation", "networkconnection.management", "networkconnection.query", "settings.read", "systemsettings.query", "tempdatabase.operation", "time.query", "universalsearch.operation", "wifi.query", "wifi.management"]
+    "requiredPermissions": ["accountsservice.management", "activity.operation", "appmanager.management", "application.launcher", "calendarremindersservice.operation", "database.operation", "networkconnection.management", "networkconnection.query", "settings.query", "systemsettings.query", "tempdatabase.operation", "time.query", "universalsearch.operation", "wifi.query", "wifi.management"]
 }

--- a/com.palm.app.clock/appinfo.json
+++ b/com.palm.app.clock/appinfo.json
@@ -12,5 +12,5 @@
 	"debug": false,
 	"removable": false,
 	"trustLevel" : "trusted",
-	"requiredPermissions": ["application.launcher", "activity.operation", "settings.read", "database.operation"]
+	"requiredPermissions": ["application.launcher", "activity.operation", "settings.query", "database.operation"]
 }

--- a/com.palm.app.contacts/appinfo.json
+++ b/com.palm.app.contacts/appinfo.json
@@ -9,5 +9,5 @@
     "icon"      : "icon.png",
     "removable" : false,
     "trustLevel" : "trusted",
-    "requiredPermissions": ["accountsservice.management", "accountsservice.operation", "application.launcher", "activity.operation", "contactslinker-service.operation", "contacts-service.operation", "database.management", "database.operation", "settings.read", "tempdatabase.management", "tempdatabase.operation"]
+    "requiredPermissions": ["accountsservice.management", "accountsservice.operation", "application.launcher", "activity.operation", "contactslinkerservice.operation", "contactsservice.operation", "database.management", "database.operation", "settings.read", "tempdatabase.management", "tempdatabase.operation"]
 }

--- a/com.palm.app.contacts/appinfo.json
+++ b/com.palm.app.contacts/appinfo.json
@@ -9,5 +9,5 @@
     "icon"      : "icon.png",
     "removable" : false,
     "trustLevel" : "trusted",
-    "requiredPermissions": ["accountsservice.management", "accountsservice.operation", "application.launcher", "activity.operation", "contactslinkerservice.operation", "contactsservice.operation", "database.management", "database.operation", "settings.read", "tempdatabase.management", "tempdatabase.operation"]
+    "requiredPermissions": ["accountsservice.management", "accountsservice.operation", "application.launcher", "activity.operation", "contactslinkerservice.operation", "contactsservice.operation", "database.management", "database.operation", "settings.query", "tempdatabase.management", "tempdatabase.operation"]
 }

--- a/com.palm.app.email/appinfo.json
+++ b/com.palm.app.email/appinfo.json
@@ -51,5 +51,5 @@
             }
         }
     },
-    "requiredPermissions": ["accountsservice.management", "accountsservice.operation", "activity.operation", "application.launcher", "application.operation", "database.operation", "filecache.operation", "filecache.management", "luna-sysmgr.operation", "mojomail-imap.operation", "mojomail-pop.operation", "mojomail-smtp.operation", "networkconnection.query", "sleep.management", "settings.read", "systemsettings.query", "tempdatabase.operation"]
+    "requiredPermissions": ["accountsservice.management", "accountsservice.operation", "activity.operation", "application.launcher", "application.operation", "database.operation", "filecache.operation", "filecache.management", "luna-sysmgr.operation", "mojomail-imap.operation", "mojomail-pop.operation", "mojomail-smtp.operation", "networkconnection.query", "sleep.management", "settings.query", "systemsettings.query", "tempdatabase.operation"]
 }


### PR DESCRIPTION
Incorrect names as spotted by the ls2 validation during build.

Fixes:
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: Found 46 group(s) used in client-permissions.d but not defined WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: === LIST BEGIN ===

WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: 'contacts-service.operation' being used in:
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   com.palm.app.contacts.app.json
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg: 'contactslinker-service.operation' being used in:
WARNING: luneos-dev-image-1.0-r0 do_validate_ls2_acg:   com.palm.app.contacts.app.json